### PR TITLE
Split names to chunks in describe ssm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/aws-parameter-store",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Split names to chunks because parameter filters can only handle 50 members at the time.